### PR TITLE
Enhance JSON story components with movement action and layout controls

### DIFF
--- a/src/lib/blocks/FlowArc.tsx
+++ b/src/lib/blocks/FlowArc.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { FloatingElement } from './FloatingElement';
 
 interface FlowArcProps {
@@ -7,14 +8,38 @@ interface FlowArcProps {
   height?: number;
   label?: string;
   gradient?: [string, string];
+  className?: string;
+  anchor?: 'center' | 'top-left';
+  zIndex?: number;
+  style?: CSSProperties;
 }
 
-export const FlowArc = ({ id, position, width = 260, height = 140, label, gradient = ['#60a5fa', '#34d399'] }: FlowArcProps) => {
+const joinClassNames = (...tokens: Array<string | false | null | undefined>) => tokens.filter(Boolean).join(' ');
+
+export const FlowArc = ({
+  id,
+  position,
+  width = 260,
+  height = 140,
+  label,
+  gradient = ['#60a5fa', '#34d399'],
+  className,
+  anchor,
+  zIndex,
+  style,
+}: FlowArcProps) => {
   const viewBoxWidth = 260;
   const viewBoxHeight = 140;
 
   return (
-    <FloatingElement id={id} position={position} className="flow-arc">
+    <FloatingElement
+      id={id}
+      position={position}
+      anchor={anchor}
+      zIndex={zIndex}
+      style={style}
+      className={joinClassNames('flow-arc', className)}
+    >
       <svg
         className="flow-arc__svg"
         width={width}

--- a/src/lib/blocks/MetricPill.tsx
+++ b/src/lib/blocks/MetricPill.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { FloatingElement } from './FloatingElement';
 import { StoryElement } from '../story/StoryElement';
 
@@ -9,12 +10,33 @@ interface MetricPillProps {
   prefix?: string;
   suffix?: string;
   className?: string;
+  anchor?: 'center' | 'top-left';
+  zIndex?: number;
+  style?: CSSProperties;
 }
 
 const joinClassNames = (...tokens: Array<string | false | undefined>) => tokens.filter(Boolean).join(' ');
 
-export const MetricPill = ({ id, valueId, label, position, prefix = '', suffix = '', className }: MetricPillProps) => (
-  <FloatingElement id={id} position={position} className={joinClassNames('metric-pill', className)}>
+export const MetricPill = ({
+  id,
+  valueId,
+  label,
+  position,
+  prefix = '',
+  suffix = '',
+  className,
+  anchor,
+  zIndex,
+  style,
+}: MetricPillProps) => (
+  <FloatingElement
+    id={id}
+    position={position}
+    anchor={anchor}
+    zIndex={zIndex}
+    style={style}
+    className={joinClassNames('metric-pill', className)}
+  >
     <span className="metric-pill__label">{label}</span>
     <StoryElement id={valueId} as="span" className="metric-pill__value story-element-inline">
       {prefix}0{suffix}

--- a/src/lib/blocks/PersonaNode.tsx
+++ b/src/lib/blocks/PersonaNode.tsx
@@ -8,6 +8,9 @@ interface PersonaNodeProps {
   theme?: 'owner' | 'buyer' | 'neutral';
   position: { x: number; y: number };
   style?: CSSProperties;
+  className?: string;
+  anchor?: 'center' | 'top-left';
+  zIndex?: number;
 }
 
 const THEME_CLASS: Record<NonNullable<PersonaNodeProps['theme']>, string> = {
@@ -16,9 +19,28 @@ const THEME_CLASS: Record<NonNullable<PersonaNodeProps['theme']>, string> = {
   neutral: 'persona-node--neutral',
 };
 
-export const PersonaNode = ({ id, name, label, theme = 'neutral', position, style }: PersonaNodeProps) => {
+const joinClassNames = (...tokens: Array<string | false | null | undefined>) => tokens.filter(Boolean).join(' ');
+
+export const PersonaNode = ({
+  id,
+  name,
+  label,
+  theme = 'neutral',
+  position,
+  style,
+  className,
+  anchor,
+  zIndex,
+}: PersonaNodeProps) => {
   return (
-    <FloatingElement id={id} position={position} className={`persona-node ${THEME_CLASS[theme]}`} style={style}>
+    <FloatingElement
+      id={id}
+      position={position}
+      anchor={anchor}
+      zIndex={zIndex}
+      className={joinClassNames('persona-node', THEME_CLASS[theme], className)}
+      style={style}
+    >
       <div className="persona-node__badge" aria-hidden>
         {name.slice(0, 1)}
       </div>

--- a/src/lib/blocks/SceneBubble.tsx
+++ b/src/lib/blocks/SceneBubble.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { FloatingElement } from './FloatingElement';
 
 interface SceneBubbleProps {
@@ -6,6 +6,10 @@ interface SceneBubbleProps {
   position: { x: number; y: number };
   tone?: 'primary' | 'success' | 'neutral';
   size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  anchor?: 'center' | 'top-left';
+  zIndex?: number;
+  style?: CSSProperties;
   children: ReactNode;
 }
 
@@ -21,8 +25,27 @@ const sizeClass: Record<NonNullable<SceneBubbleProps['size']>, string> = {
   lg: 'scene-bubble--lg',
 };
 
-export const SceneBubble = ({ id, position, tone = 'neutral', size = 'md', children }: SceneBubbleProps) => (
-  <FloatingElement id={id} position={position} className={`scene-bubble ${toneClass[tone]} ${sizeClass[size]}`}>
+const joinClassNames = (...tokens: Array<string | false | null | undefined>) => tokens.filter(Boolean).join(' ');
+
+export const SceneBubble = ({
+  id,
+  position,
+  tone = 'neutral',
+  size = 'md',
+  className,
+  anchor,
+  zIndex,
+  style,
+  children,
+}: SceneBubbleProps) => (
+  <FloatingElement
+    id={id}
+    position={position}
+    anchor={anchor}
+    zIndex={zIndex}
+    style={style}
+    className={joinClassNames('scene-bubble', toneClass[tone], sizeClass[size], className)}
+  >
     {children}
   </FloatingElement>
 );

--- a/src/lib/blocks/StoreEmblem.tsx
+++ b/src/lib/blocks/StoreEmblem.tsx
@@ -1,13 +1,27 @@
+import type { CSSProperties } from 'react';
 import { FloatingElement } from './FloatingElement';
 
 interface StoreEmblemProps {
   id: string;
   position: { x: number; y: number };
   label: string;
+  className?: string;
+  anchor?: 'center' | 'top-left';
+  zIndex?: number;
+  style?: CSSProperties;
 }
 
-export const StoreEmblem = ({ id, position, label }: StoreEmblemProps) => (
-  <FloatingElement id={id} position={position} className="store-emblem">
+const joinClassNames = (...tokens: Array<string | false | null | undefined>) => tokens.filter(Boolean).join(' ');
+
+export const StoreEmblem = ({ id, position, label, className, anchor, zIndex, style }: StoreEmblemProps) => (
+  <FloatingElement
+    id={id}
+    position={position}
+    anchor={anchor}
+    zIndex={zIndex}
+    style={style}
+    className={joinClassNames('store-emblem', className)}
+  >
     <div className="store-emblem__roof" />
     <div className="store-emblem__body">
       <div className="store-emblem__panel store-emblem__panel--left" />

--- a/src/lib/story/actions.ts
+++ b/src/lib/story/actions.ts
@@ -43,6 +43,18 @@ export const applyAction = ({ action, runtime, timeline, mode }: ApplyActionArgs
       }
       break;
     }
+    case 'animate-to': {
+      const target = runtime.elements.get(action.target);
+      if (!target) return;
+      const preset = resolvePreset(action.preset);
+      const toVars = { ...preset?.to, ...action.vars };
+      if (mode === 'instant') {
+        gsap.set(target, toVars);
+      } else {
+        timeline.to(target, toVars, '>-0.05');
+      }
+      break;
+    }
     case 'set-text': {
       const target = runtime.elements.get(action.target);
       if (!target) return;

--- a/src/lib/story/types.ts
+++ b/src/lib/story/types.ts
@@ -10,6 +10,7 @@ export type AnimationPreset =
 export type TimelineAction =
   | { type: 'animate-in'; target: string; preset?: AnimationPreset; vars?: Record<string, unknown> }
   | { type: 'animate-out'; target: string; preset?: AnimationPreset; vars?: Record<string, unknown> }
+  | { type: 'animate-to'; target: string; preset?: AnimationPreset; vars?: Record<string, unknown> }
   | { type: 'set-text'; target: string; text: string }
   | { type: 'counter'; target: string; from?: number; to: number; duration?: number; prefix?: string; suffix?: string; precision?: number }
   | { type: 'wait'; duration: number }

--- a/src/stories/data/bun-shop.json
+++ b/src/stories/data/bun-shop.json
@@ -23,6 +23,7 @@
       },
       "tone": "primary",
       "size": "lg",
+      "zIndex": 4,
       "text": "烧饼铺"
     },
     {
@@ -34,6 +35,7 @@
       },
       "tone": "success",
       "size": "md",
+      "zIndex": 5,
       "text": "利润翻倍"
     },
     {
@@ -45,6 +47,7 @@
       },
       "tone": "neutral",
       "size": "md",
+      "zIndex": 3,
       "text": "烧饼店转让"
     },
     {
@@ -54,6 +57,7 @@
         "x": 50,
         "y": 44
       },
+      "zIndex": 4,
       "label": "烧饼铺"
     },
     {
@@ -63,6 +67,7 @@
         "x": 50,
         "y": 56
       },
+      "zIndex": 2,
       "label": "王五接手"
     },
     {
@@ -74,7 +79,8 @@
       },
       "name": "张三",
       "label": "原老板",
-      "theme": "owner"
+      "theme": "owner",
+      "zIndex": 4
     },
     {
       "type": "PersonaNode",
@@ -85,7 +91,8 @@
       },
       "name": "王五",
       "label": "新老板",
-      "theme": "buyer"
+      "theme": "buyer",
+      "zIndex": 4
     },
     {
       "type": "MetricPill",
@@ -140,6 +147,7 @@
         "y": 32
       },
       "className": "growth-flare",
+      "zIndex": 6,
       "text": "增长动能释放"
     }
   ],
@@ -323,6 +331,34 @@
       ]
     },
     {
+      "id": "momentum-shift",
+      "title": "增长势能扩散",
+      "actions": [
+        {
+          "type": "animate-to",
+          "target": "growth-flare",
+          "vars": {
+            "yPercent": -18,
+            "duration": 0.9,
+            "ease": "sine.inOut",
+            "yoyo": true,
+            "repeat": 1
+          }
+        },
+        {
+          "type": "animate-to",
+          "target": "label-growth",
+          "vars": {
+            "scale": 1.08,
+            "duration": 0.9,
+            "ease": "sine.inOut",
+            "yoyo": true,
+            "repeat": 1
+          }
+        }
+      ]
+    },
+    {
       "id": "profit-growth",
       "title": "利润跃升",
       "actions": [
@@ -341,6 +377,26 @@
           "to": 40,
           "duration": 0.8,
           "suffix": "%"
+        }
+      ]
+    },
+    {
+      "id": "curtain-call",
+      "title": "舞台收束",
+      "actions": [
+        {
+          "type": "animate-out",
+          "target": "growth-flare",
+          "vars": {
+            "duration": 0.6
+          }
+        },
+        {
+          "type": "animate-out",
+          "target": "label-growth",
+          "vars": {
+            "duration": 0.6
+          }
         }
       ]
     }

--- a/src/stories/registry.tsx
+++ b/src/stories/registry.tsx
@@ -16,7 +16,7 @@ import {
   FloatingElement,
   StoryElement,
 } from '../lib';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 interface PositionConfig {
   x: number;
@@ -25,16 +25,81 @@ interface PositionConfig {
 
 type LayoutElementConfig =
   | { type: 'StoryElement'; id: string; className?: string }
-  | { type: 'SceneBubble'; id: string; position: PositionConfig; tone?: 'primary' | 'success' | 'neutral'; size?: 'sm' | 'md' | 'lg'; text: string }
-  | { type: 'PersonaNode'; id: string; position: PositionConfig; name: string; label?: string; theme?: 'owner' | 'buyer' | 'neutral' }
-  | { type: 'FlowArc'; id: string; position: PositionConfig; label?: string; width?: number; height?: number; gradient?: [string, string] }
-  | { type: 'StoreEmblem'; id: string; position: PositionConfig; label: string }
-  | { type: 'MetricPill'; id: string; position: PositionConfig; valueId: string; label: string; prefix?: string; suffix?: string; className?: string }
-  | { type: 'FloatingElement'; id: string; position: PositionConfig; className?: string; text?: string; anchor?: 'center' | 'top-left'; zIndex?: number };
+  | {
+      type: 'SceneBubble';
+      id: string;
+      position: PositionConfig;
+      tone?: 'primary' | 'success' | 'neutral';
+      size?: 'sm' | 'md' | 'lg';
+      text: string;
+      className?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    }
+  | {
+      type: 'PersonaNode';
+      id: string;
+      position: PositionConfig;
+      name: string;
+      label?: string;
+      theme?: 'owner' | 'buyer' | 'neutral';
+      className?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    }
+  | {
+      type: 'FlowArc';
+      id: string;
+      position: PositionConfig;
+      label?: string;
+      width?: number;
+      height?: number;
+      gradient?: [string, string];
+      className?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    }
+  | {
+      type: 'StoreEmblem';
+      id: string;
+      position: PositionConfig;
+      label: string;
+      className?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    }
+  | {
+      type: 'MetricPill';
+      id: string;
+      position: PositionConfig;
+      valueId: string;
+      label: string;
+      prefix?: string;
+      suffix?: string;
+      className?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    }
+  | {
+      type: 'FloatingElement';
+      id: string;
+      position: PositionConfig;
+      className?: string;
+      text?: string;
+      anchor?: 'center' | 'top-left';
+      zIndex?: number;
+      style?: CSSProperties;
+    };
 
 type JsonAction =
   | { type: 'animate-in'; target: string; preset?: string; vars?: Record<string, unknown> }
   | { type: 'animate-out'; target: string; preset?: string; vars?: Record<string, unknown> }
+  | { type: 'animate-to'; target: string; preset?: string; vars?: Record<string, unknown> }
   | { type: 'set-text'; target: string; text: string }
   | { type: 'counter'; target: string; from?: number; to: number; duration?: number; prefix?: string; suffix?: string; precision?: number }
   | { type: 'wait'; duration: number }
@@ -119,6 +184,47 @@ const toTimelineAction = (action: JsonAction): TimelineAction => {
   return action as TimelineAction;
 };
 
+const registerElementId = (
+  registry: Map<string, string>,
+  id: string,
+  source: string,
+  storyId: string,
+) => {
+  if (!id) return;
+  if (registry.has(id)) {
+    console.warn(
+      `[Story:${storyId}] Duplicate element id "${id}" defined in ${source} (previously in ${registry.get(id) ?? 'unknown'})`,
+    );
+    return;
+  }
+  registry.set(id, source);
+};
+
+const actionHasTarget = (action: JsonAction): action is JsonAction & { target: string } => {
+  return 'target' in action && typeof action.target === 'string';
+};
+
+const validateStory = (story: StoryFile) => {
+  const registry = new Map<string, string>();
+
+  story.layout.forEach((item, index) => {
+    registerElementId(registry, item.id, `layout[${index}]<${item.type}>`, story.id);
+    if (item.type === 'MetricPill') {
+      registerElementId(registry, item.valueId, `layout[${index}]<${item.type}>.valueId`, story.id);
+    }
+  });
+
+  story.steps.forEach((step) => {
+    step.actions.forEach((action, actionIndex) => {
+      if (actionHasTarget(action) && !registry.has(action.target)) {
+        console.warn(
+          `[Story:${story.id}] Step "${step.id}" action[${actionIndex}] (${action.type}) references unknown target "${action.target}"`,
+        );
+      }
+    });
+  });
+};
+
 const resolveSteps = (steps: JsonStep[]): StepDefinition[] =>
   steps.map((step) => ({
     id: step.id,
@@ -139,6 +245,10 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
           position={config.position}
           tone={config.tone}
           size={config.size}
+          className={config.className}
+          anchor={config.anchor}
+          zIndex={config.zIndex}
+          style={config.style}
         >
           {config.text}
         </SceneBubble>
@@ -152,6 +262,10 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
           name={config.name}
           label={config.label}
           theme={config.theme}
+          className={config.className}
+          anchor={config.anchor}
+          zIndex={config.zIndex}
+          style={config.style}
         />
       );
     case 'FlowArc':
@@ -164,10 +278,25 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
           width={config.width}
           height={config.height}
           gradient={config.gradient}
+          className={config.className}
+          anchor={config.anchor}
+          zIndex={config.zIndex}
+          style={config.style}
         />
       );
     case 'StoreEmblem':
-      return <StoreEmblem key={config.id} id={config.id} position={config.position} label={config.label} />;
+      return (
+        <StoreEmblem
+          key={config.id}
+          id={config.id}
+          position={config.position}
+          label={config.label}
+          className={config.className}
+          anchor={config.anchor}
+          zIndex={config.zIndex}
+          style={config.style}
+        />
+      );
     case 'MetricPill':
       return (
         <MetricPill
@@ -179,6 +308,9 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
           prefix={config.prefix}
           suffix={config.suffix}
           className={config.className}
+          anchor={config.anchor}
+          zIndex={config.zIndex}
+          style={config.style}
         />
       );
     case 'FloatingElement':
@@ -190,6 +322,7 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
           className={config.className}
           anchor={config.anchor}
           zIndex={config.zIndex}
+          style={config.style}
         >
           {config.text}
         </FloatingElement>
@@ -199,15 +332,18 @@ const renderLayoutElement = (config: LayoutElementConfig): ReactNode => {
   }
 };
 
-const toResolvedStory = (story: StoryFile): ResolvedStory => ({
-  id: story.id,
-  title: story.title,
-  summary: story.summary,
-  tags: story.tags ?? [],
-  stageTheme: story.stageTheme,
-  layout: story.layout,
-  steps: resolveSteps(story.steps),
-});
+const toResolvedStory = (story: StoryFile): ResolvedStory => {
+  validateStory(story);
+  return {
+    id: story.id,
+    title: story.title,
+    summary: story.summary,
+    tags: story.tags ?? [],
+    stageTheme: story.stageTheme,
+    layout: story.layout,
+    steps: resolveSteps(story.steps),
+  };
+};
 
 const JsonStoryExperience = ({ story, onBack }: { story: ResolvedStory; onBack: () => void }) => (
   <div className="story-shell story-shell--immersive">


### PR DESCRIPTION
## Summary
- allow JSON-driven blocks like scene bubbles, personas, arcs, emblems, and metrics to accept class names, anchors, z-index, and inline styles for finer layout tuning
- add an `animate-to` timeline action plus runtime validation to keep story element references consistent
- refresh the bun-shop sample story to showcase layered positioning and new movement/fade choreography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da78c42978832c93aae17a98acf113